### PR TITLE
[ci] Add artifactory remote to upload built packages

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -36,11 +36,9 @@ on:
         required: false
         default: conanfile.py
         description: "Name of the conanfile, typically it will be `conanfile.txt` or `conanfile.py`"
-    secrets:
-      RT_TOKEN:
-        required: false
-      RT_USERNAME:
-        required: false
+    with:
+      rt_username: ${{ secrets.RT_USERNAME }}
+      rt_token: ${{ secrets.RT_TOKEN }}
 
 env:
   CONAN_USER_HOME: /home/conan
@@ -58,6 +56,8 @@ jobs:
       CONAN_USER_HOME: /home/conan
       CONAN_SYSREQUIRES_MODE: enabled
       CONAN_PRINT_RUN_COMMANDS: 1
+      RT_USERNAME: ${{ secrets.RT_USERNAME }}
+      RT_TOKEN: ${{ secrets.RT_TOKEN }}
     steps:
 
       - name: Install jq
@@ -90,7 +90,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r=remote-project -p=${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
+          conan user -r=remote-project -p=$RT_TOKEN $RT_USERNAME
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r remote-project -p ${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
+          conan user -r=remote-project -p=${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: conanfile.py
         description: "Name of the conanfile, typically it will be `conanfile.txt` or `conanfile.py`"
+    secrets:
+      RT_TOKEN:
+        required: true
+      RT_USERNAME:
+        required: true
 
 env:
   CONAN_USER_HOME: /home/conan

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -36,9 +36,6 @@ on:
         required: false
         default: conanfile.py
         description: "Name of the conanfile, typically it will be `conanfile.txt` or `conanfile.py`"
-    with:
-      rt_username: ${{ secrets.RT_USERNAME }}
-      rt_token: ${{ secrets.RT_TOKEN }}
 
 env:
   CONAN_USER_HOME: /home/conan

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r=remote-project -p=$RT_TOKEN $RT_USERNAME
+          conan user -r=remote-project -p=${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -38,9 +38,9 @@ on:
         description: "Name of the conanfile, typically it will be `conanfile.txt` or `conanfile.py`"
     secrets:
       RT_TOKEN:
-        required: true
+        required: false
       RT_USERNAME:
-        required: true
+        required: false
 
 env:
   CONAN_USER_HOME: /home/conan
@@ -58,8 +58,6 @@ jobs:
       CONAN_USER_HOME: /home/conan
       CONAN_SYSREQUIRES_MODE: enabled
       CONAN_PRINT_RUN_COMMANDS: 1
-      RT_USERNAME: ${{ secrets.RT_USERNAME }}
-      RT_TOKEN: ${{ secrets.RT_TOKEN }}
     steps:
 
       - name: Install jq

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r=remote-project -p=${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
+          conan user -r remote-project -p ${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -37,7 +37,11 @@ on:
         required: false
         default: conanfile.txt
         description: "Name of the conanfile, typically it will be `conanfile.txt` or `conanfile.py`"
-
+    secrets:
+      RT_TOKEN:
+        required: true
+      RT_USERNAME:
+        required: true
 
 jobs:
   build_and_test:

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -68,6 +68,12 @@ jobs:
           conan --version
           conan config home
 
+      - name: Connect to remote (project)
+        if: ${{ inputs.remote_project }}
+        run: |
+          conan remote add -i 0 remote-project ${{ inputs.remote_project }}
+          conan user -r remote-project -p ${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
+
       - name: Prepare deps
         run: |
           cp -r .conan/* $(conan config home)
@@ -79,6 +85,11 @@ jobs:
           conan install ../${{ inputs.conanfile }} --profile:host=${{ inputs.profile }} --profile:build=default --build=missing --update
           cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
           cmake --build . --config Release --target flappy-frog
+
+      - name: Upload packages that have being built
+        if: ${{ inputs.remote_project }}
+        run: |
+          conan upload --confirm --parallel --all --remote remote-project *
 
       # - name: Run tests
       #   if: ${{ inputs.run_tests }}

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -45,8 +45,6 @@ jobs:
     env:
       CONAN_SYSREQUIRES_MODE: enabled
       CONAN_PRINT_RUN_COMMANDS: 1
-      RT_USERNAME: ${{ secrets.RT_USERNAME }}
-      RT_TOKEN: ${{ secrets.RT_TOKEN }}
     steps:
 
       - name: Install jq
@@ -78,7 +76,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r=remote-project -p=$RT_TOKEN $RT_USERNAME
+         conan user -r=remote-project -p=${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r=remote-project -p=${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
+          conan user -r remote-project -p ${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
 
       - name: Prepare deps
         run: |
@@ -97,7 +97,7 @@ jobs:
       - name: Upload packages that have being built
         if: ${{ inputs.remote_project }}
         run: |
-          conan upload --confirm --parallel --all --remote remote-project *
+          conan upload --confirm --parallel --all --remote remote-project '*'
 
       # - name: Run tests
       #   if: ${{ inputs.run_tests }}

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r remote-project -p ${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
+          conan user -r=remote-project -p=${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: true
         description: "Version of the library."
+      remote_project:
+        type: string
+        required: false
+        default: ""
       profile:
         type: string
         required: true

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-         conan user -r=remote-project -p=${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
+          conan user -r=remote-project -p=${{ secrets.RT_TOKEN }} ${{ secrets.RT_USERNAME }}
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -39,9 +39,9 @@ on:
         description: "Name of the conanfile, typically it will be `conanfile.txt` or `conanfile.py`"
     secrets:
       RT_TOKEN:
-        required: true
+        required: false
       RT_USERNAME:
-        required: true
+        required: false
 
 jobs:
   build_and_test:
@@ -104,4 +104,3 @@ jobs:
       #   run: |
       #     cd build
       #     ${{ inputs.run_tests }}
-  

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -45,6 +45,8 @@ jobs:
     env:
       CONAN_SYSREQUIRES_MODE: enabled
       CONAN_PRINT_RUN_COMMANDS: 1
+      RT_USERNAME: ${{ secrets.RT_USERNAME }}
+      RT_TOKEN: ${{ secrets.RT_TOKEN }}
     steps:
 
       - name: Install jq
@@ -76,7 +78,7 @@ jobs:
         if: ${{ inputs.remote_project }}
         run: |
           conan remote add -i 0 remote-project ${{ inputs.remote_project }}
-          conan user -r=remote-project -p=${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
+          conan user -r=remote-project -p=$RT_TOKEN $RT_USERNAME
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       library_version: ${{ needs.cmakelists-version.outputs.LIBRARY_VERSION }}
       github_sha: ${{ github.sha }}
       profile: release
+      remote_project: https://bateltest.jfrog.io/artifactory/api/conan/flappy-frog-project-conan-local
       conanfile: conanfile.py
 
   ci-macos-release:
@@ -33,4 +34,5 @@ jobs:
       library_name: ${{ github.event.repository.name }}
       library_version: ${{ needs.cmakelists-version.outputs.LIBRARY_VERSION }}
       profile: ios
+      remote_project: https://bateltest.jfrog.io/artifactory/api/conan/flappy-frog-project-conan-local
       conanfile: conanfile.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       profile: release
       remote_project: https://bateltest.jfrog.io/artifactory/api/conan/flappy-frog-project-conan-local
       conanfile: conanfile.py
+    secrets:
+      RT_USERNAME: ${{ secrets.RT_USERNAME }}
+      RT_TOKEN: ${{ secrets.RT_TOKEN }}
 
   ci-macos-release:
     needs:
@@ -36,3 +39,6 @@ jobs:
       profile: ios
       remote_project: https://bateltest.jfrog.io/artifactory/api/conan/flappy-frog-project-conan-local
       conanfile: conanfile.py
+    secrets:
+      RT_USERNAME: ${{ secrets.RT_USERNAME }}
+      RT_TOKEN: ${{ secrets.RT_TOKEN }}


### PR DESCRIPTION
In replacement of #36 as PRs from forks cannot access github secrets

Added both repository secrets for this to work:
- RT_USERNAME
- RT_TOKEN